### PR TITLE
Version 0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 2023-04-19
 
+### Version 0.1.6
+
+* run method now returns a dictionary of the certificate chain files
+
 ### Version 0.1.5
 
 * Refactored the normalize_subject method to use a list comprehension.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,7 +9,7 @@
 project = "get_certificate_chain"
 copyright = "2023, Calvin Remsburg, Nolan Rumble"
 author = "Calvin Remsburg, Nolan Rumble"
-release = "0.1.5"
+release = "0.1.6"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "get_certificate_chain"
-version = "0.1.5"
+version = "0.1.6"
 description = "Project to help use the breadcrumbs that are left by the certificate to build the chain and output it into files."
 authors = ["Calvin Remsburg <cremsburg.dev@gmail.com>", " TheScriptGuy <@nolanrumble>"]
 license = "MIT"


### PR DESCRIPTION
### Version 0.1.6

* run method now returns a dictionary of the certificate chain files

```python
from get_certificate_chain.download import SSLCertificateChainDownloader

downloader = SSLCertificateChainDownloader(output_directory="/var/tmp")
x = downloader.run({"host": "www.google.com"})

type(x)
dict

print(x)
{'files': ['/var/tmp/1-CN_GTS_CA_1C3_O_Google_Trust_Services_LLC_C_US.crt', '/var/tmp/2-CN_www_google_com.crt', '/var/tmp/0-CN_GTS_Root_R1_O_Google_Trust_Services_LLC_C_US.crt']}
```